### PR TITLE
Allow resolver to accept nested parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,13 @@ pip install git+https://github.com/Sceptre/sceptre-request-resolver.git
 parameters|sceptre_user_data:
   <name>: !request <API ENDPOINT>
 ```
+
+```yaml
+parameters|sceptre_user_data:
+  <name>: !request
+    url: <API ENDPOINT>
+```
+
 __Note__: This resolver always returns a string.
 
 

--- a/resolver/request.py
+++ b/resolver/request.py
@@ -39,11 +39,7 @@ class Request(Resolver):
         :rtype: str
         """
 
-        args = self.argument
-        url = args
-
-        if isinstance(args, dict):
-            url = args.get("url")
+        url = self.argument.get("url") if isinstance(self.argument, dict) else self.argument
 
         if checkers.is_url(url):
             response = self._make_request(url)

--- a/resolver/request.py
+++ b/resolver/request.py
@@ -39,7 +39,11 @@ class Request(Resolver):
         :rtype: str
         """
 
-        url = self.argument.get("url") if isinstance(self.argument, dict) else self.argument
+        url = (
+            self.argument.get("url")
+            if isinstance(self.argument, dict)
+            else self.argument
+        )
 
         if checkers.is_url(url):
             response = self._make_request(url)

--- a/resolver/request.py
+++ b/resolver/request.py
@@ -39,10 +39,15 @@ class Request(Resolver):
         :rtype: str
         """
 
-        arg = self.argument
-        if checkers.is_url(arg):
-            response = self._make_request(arg)
+        args = self.argument
+        url = args
+
+        if isinstance(args, dict):
+            url = args.get("url")
+
+        if checkers.is_url(url):
+            response = self._make_request(url)
         else:
-            raise InvalidResolverArgumentValueError(f"Invalid argument: {arg}")
+            raise InvalidResolverArgumentValueError(f"Invalid argument: {url}")
 
         return response

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -19,6 +19,8 @@ class TestRequestResolver:
             (""),
             ("invalid"),
             ("foo://acme.org/invalid"),
+            ({"url": None}),
+            ({"url": "invalid"}),
         ],
     )
     def test_resolve_with_invalid_args(self, arg):
@@ -26,11 +28,14 @@ class TestRequestResolver:
             self.resolver.argument = arg
             self.resolver.resolve()
 
+    @pytest.mark.parametrize(
+        "arg",
+        [("https://fake-endpoint.org"), ({"url": "https://fake-endpoint.org"})],
+    )
     @patch(
         "resolver.request.Request._make_request", MagicMock(return_value=fake_response)
     )
-    def test_resolve_with_valid_arg(self):
-        endpoint = "https://fake-endpoint.org"
-        self.resolver.argument = endpoint
+    def test_resolve_with_valid_args(self, arg):
+        self.resolver.argument = arg
         response = self.resolver.resolve()
         assert response == fake_response


### PR DESCRIPTION
This allows users to specify a `url` parameter for this resolver.